### PR TITLE
http-and-json-support

### DIFF
--- a/docs/CHZ-create-document-v3.md
+++ b/docs/CHZ-create-document-v3.md
@@ -1,0 +1,173 @@
+# Честный знак: Создание документа (v3)
+
+Эндпоинт: POST /api/v3/lk/documents/create
+
+Запрос может принимать параметр product_group в query (pg), пример: /api/v3/lk/documents/create?pg=milk. Допустимо также передавать product_group в теле запроса (см. ниже).
+
+Заголовки
+- Content-Type: application/json
+- Authorization: Bearer <токен>
+
+Пример запроса (cURL) — с product_group в query
+```
+curl "https://ismp.crpt.ru/api/v3/lk/documents/create?pg=milk" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <ТОКЕН>" \
+  --data-binary '{
+    "product_document": "<документ в base64>",
+    "document_format": "MANUAL",
+    "type": "LP_INTRODUCE_GOODS",
+    "signature": "<откреплённая подпись (УКЭП, CMS/PKCS#7) в base64>"
+  }'
+```
+
+Альтернативный пример — с product_group в теле
+```
+curl "https://ismp.crpt.ru/api/v3/lk/documents/create" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <ТОКЕН>" \
+  --data-binary '{
+    "product_document": "<документ в base64>",
+    "document_format": "MANUAL",
+    "type": "LP_INTRODUCE_GOODS",
+    "signature": "<откреплённая подпись (УКЭП, CMS/PKCS#7) в base64>",
+    "product_group": "milk"
+  }'
+```
+
+Шаблон тела запроса (JSON)
+```
+{
+  "document_format": "MANUAL|XML|CSV",
+  "product_document": "<Base64 исходного документа>",
+  "product_group": "<код группы, опционально>",
+  "signature": "<Base64 откреплённой подписи (УКЭП, CMS/PKCS#7)>",
+  "type": "<тип документа>"
+}
+```
+
+Тело запроса (описание полей)
+- document_format: enum (обязателен)
+  - Формат исходного документа:
+    - MANUAL — JSON (в product_document кладётся Base64 от JSON-строки, например Base64(JSON.stringify(...)))
+    - XML — XML (в product_document кладётся Base64 от XML)
+    - CSV — CSV (в product_document кладётся Base64 от CSV)
+- product_document: string (обязателен)
+  - Содержимое исходного документа, закодированное в Base64 (см. привязку к document_format выше).
+- type: enum (обязателен)
+  - Тип документа (см. перечень ниже), например: LP_INTRODUCE_GOODS.
+- signature: string (обязателен)
+  - Откреплённая подпись (УКЭП, как правило CMS/PKCS#7) в Base64.
+- product_group: string (опционален)
+  - Код группы товаров; может указываться как поле тела или как query-параметр `pg`.
+
+Параметры запроса (query)
+- pg (product_group): string (опционален)
+  - Группа товаров. Допустимо вместо `pg` передавать поле `product_group` в теле.
+  - Примеры кодов по документации ЧЗ (не исчерпывающе):
+    - clothes — одежда и изделия лёгкой промышленности
+    - shoes — обувь
+    - tobacco — табачная продукция
+    - perfumery — парфюмерия
+    - tires — шины и покрышки
+    - electronics — электроника (включая фото/видеотехнику и крупную бытовую)
+    - pharma — лекарственные средства
+    - milk — молочная продукция
+    - bicycle — велосипеды и рамы
+    - wheelchairs — кресла-коляски
+
+Пример успешного ответа
+```
+{
+  "value": "9abd3d41-76bc-4542-a88e-b1f7be8130b5"
+}
+```
+
+Структура ответа (сводка)
+- value: string — идентификатор созданного документа (UUID)
+- При ошибке возможны поля:
+  - code: string — код ошибки
+  - error_message: string — сообщение об ошибке
+  - description: string — описание ошибки
+
+Перечень значений поля type (enum)
+- AGGREGATION_DOCUMENT — агрегация (JSON)
+- AGGREGATION_DOCUMENT_CSV — агрегация (CSV)
+- AGGREGATION_DOCUMENT_XML — агрегация (XML)
+- DISAGGREGATION_DOCUMENT — деагрегация (JSON)
+- DISAGGREGATION_DOCUMENT_CSV — деагрегация (CSV)
+- DISAGGREGATION_DOCUMENT_XML — деагрегация (XML)
+- REAGGREGATION_DOCUMENT — реагрегация (JSON)
+- REAGGREGATION_DOCUMENT_CSV — реагрегация (CSV)
+- REAGGREGATION_DOCUMENT_XML — реагрегация (XML)
+- LP_INTRODUCE_GOODS — ввод в оборот (JSON)
+- LP_INTRODUCE_GOODS_CSV — ввод в оборот (CSV)
+- LP_INTRODUCE_GOODS_XML — ввод в оборот (XML)
+- LP_SHIP_GOODS — отгрузка (JSON)
+- LP_SHIP_GOODS_CSV — отгрузка (CSV)
+- LP_SHIP_GOODS_XML — отгрузка (XML)
+- LP_ACCEPT_GOODS — приёмка (JSON)
+- LP_ACCEPT_GOODS_XML — приёмка (XML)
+- LK_REMARK — перемаркировка (JSON)
+- LK_REMARK_CSV — перемаркировка (CSV)
+- LK_REMARK_XML — перемаркировка (XML)
+- LK_RECEIPT — чек по приёмке из ИСМП (JSON)
+- LK_RECEIPT_XML — чек по приёмке из ИСМП (XML)
+- LK_RECEIPT_CSV — чек по приёмке из ИСМП (CSV)
+- LP_GOODS_IMPORT — импорт (JSON)
+- LP_GOODS_IMPORT_CSV — импорт (CSV)
+- LP_GOODS_IMPORT_XML — импорт (XML)
+- LP_CANCEL_SHIPMENT — отмена отгрузки (JSON)
+- LP_CANCEL_SHIPMENT_CSV — отмена отгрузки (CSV)
+- LP_CANCEL_SHIPMENT_XML — отмена отгрузки (XML)
+- LK_KM_CANCELLATION — аннулирование КМ (JSON)
+- LK_KM_CANCELLATION_CSV — аннулирование КМ (CSV)
+- LK_KM_CANCELLATION_XML — аннулирование КМ (XML)
+- LK_APPLIED_KM_CANCELLATION — аннулирование КМ (применённые) (JSON)
+- LK_APPLIED_KM_CANCELLATION_CSV — аннулирование КМ (применённые) (CSV)
+- LK_APPLIED_KM_CANCELLATION_XML — аннулирование КМ (применённые) (XML)
+- LK_CONTRACT_COMMISSIONING — ввод в оборот по договору (JSON)
+- LK_CONTRACT_COMMISSIONING_CSV — ввод в оборот по договору (CSV)
+- LK_CONTRACT_COMMISSIONING_XML — ввод в оборот по договору (XML)
+- LK_INDI_COMMISSIONING — ввод в оборот единичного товара (JSON)
+- LK_INDI_COMMISSIONING_CSV — ввод в оборот единичного товара (CSV)
+- LK_INDI_COMMISSIONING_XML — ввод в оборот единичного товара (XML)
+- LP_SHIP_RECEIPT — приёмка отгрузки (JSON)
+- LP_SHIP_RECEIPT_CSV — приёмка отгрузки (CSV)
+- LP_SHIP_RECEIPT_XML — приёмка отгрузки (XML)
+- OST_DESCRIPTION — описание остатков (JSON)
+- OST_DESCRIPTION_CSV — описание остатков (CSV)
+- OST_DESCRIPTION_XML — описание остатков (XML)
+- CROSSBORDER — кроссбордер (JSON)
+- CROSSBORDER_CSV — кроссбордер (CSV)
+- CROSSBORDER_XML — кроссбордер (XML)
+- LP_INTRODUCE_OST — ввод остатков (JSON)
+- LP_INTRODUCE_OST_CSV — ввод остатков (CSV)
+- LP_INTRODUCE_OST_XML — ввод остатков (XML)
+- LP_RETURN — возврат (JSON)
+- LP_RETURN_CSV — возврат (CSV)
+- LP_RETURN_XML — возврат (XML)
+- LP_SHIP_GOODS_CROSSBORDER — отгрузка для кроссбордера (JSON)
+- LP_SHIP_GOODS_CROSSBORDER_CSV — отгрузка для кроссбордера (CSV)
+- LP_SHIP_GOODS_CROSSBORDER_XML — отгрузка для кроссбордера (XML)
+- LP_CANCEL_SHIPMENT_CROSSBORDER — отмена отгрузки для кроссбордера (JSON)
+
+Связанные эндпоинты (по исходнику)
+- /api/v3/lk/documents/commissioning/indi/create — ввод в оборот единичного товара
+- /api/v3/lk/documents/commissioning/contract/create — ввод в оборот по договору
+- /api/v3/lk/documents/send — отправка документов
+- /api/v3/lk/import/send — импорт (пакетная отправка)
+- /api/v3/lk/receipt/send — отправка чеков
+- /api/v3/lk/documents/shipment/create — создание отгрузки
+- /api/v3/lk/documents/shipment/cancel — отмена отгрузки
+- /api/v3/lk/documents/reaggregation/create — реагрегация
+- /api/v3/lk/remarking/send — перемаркировка
+- /api/v3/lk/documents/acceptance/create — приёмка
+- /api/v3/lk/documents/disaggregation/create — деагрегация
+- /api/v3/lk/documents/km/cancellation/applied/create — аннулирование КМ (применённые)
+- /api/v3/lk/documents/km/cancellation/create — аннулирование КМ
+- /api/v3/lk/documents/aggregation/create — агрегация
+
+Примечания
+- Метод универсальный: может применяться вместо специализированных методов создания документов по конкретным типам (при наличии соответствующей конфигурации).
+- В исходном RTF обнаружены артефакты кодировки; приведённый конспект нормализован.

--- a/docs/CrptApi-Javadoc-skeleton.md
+++ b/docs/CrptApi-Javadoc-skeleton.md
@@ -1,0 +1,393 @@
+# CrptApi — Javadoc-скелет и перечень внутренних типов (без кода)
+
+Назначение: готовые Javadoc-блоки и список публичных/внутренних членов для переноса в один файл `CrptApi.java` (без реализации). Скелет описывает потокобезопасность, ограничение частоты (rate limiting) и сетевое взаимодействие.
+
+Важные допущения (уточнить по документации ЧЗ):
+- Эндпоинт и JSON-схема для «создания документа для ввода в оборот товара, произведенного в РФ».
+- Где передавать подпись (в теле или заголовке), формат подписи (обычно Base64).
+- Политики таймаутов/повторов, использование идемпотентности.
+
+---
+
+## 1) Класс и пакет — Javadoc для вставки в `CrptApi.java`
+
+/**
+ * Клиент для обращения к API «Честный знак» с поддержкой потокобезопасного
+ * ограничения числа запросов (ограничение частоты) и блокирующей семантики,
+ * задаваемой в конструкторе через интервал {@link java.util.concurrent.TimeUnit}
+ * и максимально допустимое число запросов в этом интервале.
+ * <p>
+ * Потокобезопасность: экземпляр является thread-safe. Метод отправки запросов
+ * может вызываться из нескольких потоков одновременно. При исчерпании лимита
+ * новые вызовы будут блокироваться до освобождения окна.
+ * <p>
+ * Семантика ограничения:
+ * <ul>
+ *   <li>В любой скользящий интервал времени длиной, равной указанному
+ *       {@code timeUnit}, будет выполнено не более {@code requestLimit} запросов.</li>
+ *   <li>При достижении лимита новые обращения блокируются до момента, когда
+ *       выполнение ещё одного запроса не приведёт к превышению лимита.</li>
+ *   <li>Ожидание поддерживает прерывание потока (см. {@link InterruptedException}).</li>
+ * </ul>
+ * <p>
+ * Сетевое взаимодействие:
+ * <ul>
+ *   <li>Сериализация запроса выполняется в JSON.</li>
+ *   <li>HTTP-клиент и сериализатор JSON инкапсулированы и могут быть переопределены
+ *       (см. внутренние интерфейсы {@code HttpExecutor}, {@code JsonSerializer}).</li>
+ *   <li>Базовый URL, заголовки, таймауты и место передачи подписи настраиваются
+ *       через билдер либо расширенный конструктор.</li>
+ * </ul>
+ * <p>
+ * Расширяемость: архитектура предусматривает внутренние интерфейсы и реализации
+ * по умолчанию, которые можно заменить без изменения публичного контракта класса.
+ * Все дополнительные типы расположены как вложенные (nested) в {@code CrptApi}.
+ * <p>
+ * Жизненный цикл: в случае наличия внутренних планировщиков/ресурсов предусмотрен
+ * метод {@code close()} (реализация {@link java.lang.AutoCloseable}).
+ * <p>
+ * Ограничения файла: все используемые типы (кроме JDK/зависимостей) должны быть
+ * внутренними классами/интерфейсами/enum текущего файла.
+ *
+ * @author 
+ * @since 0.1.0
+ */
+
+---
+
+## 2) Конструкторы — Javadoc-сигнатуры (без реализации)
+
+/**
+ * Создаёт клиент с ограничением числа запросов: не более {@code requestLimit}
+ * за интервал {@code timeUnit}. Экземпляр потокобезопасен.
+ *
+ * Предусловия:
+ * <ul>
+ *   <li>{@code timeUnit} не равен {@code null};</li>
+ *   <li>{@code requestLimit} > 0;</li>
+ * </ul>
+ *
+ * Поведение при превышении лимита:
+ * <ul>
+ *   <li>Вызовы методов отправки будут блокироваться до освобождения окна.</li>
+ *   <li>Ожидание поддерживает прерывание (см. {@link InterruptedException}).</li>
+ * </ul>
+ *
+ * @param timeUnit интервал окна для ограничения (секунда, минута и т.д.)
+ * @param requestLimit максимальное число запросов в указанном интервале (> 0)
+ * @throws IllegalArgumentException если {@code requestLimit} <= 0
+ * @throws NullPointerException если {@code timeUnit} == null
+ */
+public CrptApi(java.util.concurrent.TimeUnit timeUnit, int requestLimit) { /* no code */ }
+
+/**
+ * Расширенный конструктор/билдер (рекомендуется использовать билдер) для
+ * конфигурации HTTP-клиента, сериализации JSON, базового URL, заголовков,
+ * таймаутов, стратегии размещения подписи и источника времени.
+ *
+ * @param builder сконфигурированный билдер клиента
+ * @throws IllegalArgumentException если параметры некорректны
+ * @see CrptApi.Builder
+ */
+public CrptApi(CrptApi.Builder builder) { /* no code */ }
+
+---
+
+## 3) Публичный метод API — Javadoc-сигнатуры (без реализации)
+
+/**
+ * Создание документа для ввода в оборот товара, произведённого в РФ.
+ * <p>
+ * Блокирующая семантика: если лимит запросов на интервал исчерпан, вызов будет
+ * блокироваться до момента, пока выполнение не станет допустимым согласно
+ * ограничениям. Блокировка может быть прервана через {@link Thread#interrupt()}.
+ * <p>
+ * Сериализация: объект {@code document} сериализуется в JSON. Подпись
+ * {@code signature} передаётся согласно текущей стратегии (в заголовке или теле).
+ * <p>
+ * Сетевое поведение: реализуется через внутренний {@code HttpExecutor};
+ * таймауты, повторные попытки и пр. — согласно конфигурации.
+ *
+ * Контракт ошибок:
+ * <ul>
+ *   <li>{@link InterruptedException} — поток был прерван во время ожидания разрешения.</li>
+ *   <li>{@link CrptApi.CrptApiException} — ошибка сериализации/HTTP/протокола API.</li>
+ * </ul>
+ *
+ * @param document объект доменной модели документа (не null)
+ * @param signature строковое представление подписи (например, Base64; не null)
+ * @return неизменяемый результат, содержащий HTTP-код, тело и заголовки ответа
+ * @throws NullPointerException если {@code document} или {@code signature} равны null
+ * @throws InterruptedException при прерывании ожидания в лимитере
+ * @throws CrptApi.CrptApiException при ошибках сериализации/HTTP/ответа API
+ */
+public CrptApi.Result createDocumentForDomesticGoods(Object document, String signature)
+        throws InterruptedException, CrptApi.CrptApiException { /* no code */ }
+
+/**
+ * Перегрузка с возможностями расширенной конфигурации вызова (например, указание
+ * специфичных заголовков, идемпотентного ключа, локальных таймаутов запроса).
+ *
+ * @param document объект доменной модели
+ * @param signature подпись
+ * @param options дополнительные параметры конкретного вызова
+ * @return результат запроса
+ * @throws InterruptedException если ожидание лимита было прервано
+ * @throws CrptApi.CrptApiException при ошибках сериализации/HTTP/ответа API
+ */
+public CrptApi.Result createDocumentForDomesticGoods(Object document,
+                                                    String signature,
+                                                    CrptApi.CallOptions options)
+        throws InterruptedException, CrptApi.CrptApiException { /* no code */ }
+
+---
+
+## 4) Управление ресурсами — Javadoc-сигнатуры
+
+/**
+ * Закрывает внутренние ресурсы клиента (если используются фоновые планировщики,
+ * пулы подключений и пр.). Повторный вызов безопасен и не приводит к ошибкам.
+ *
+ * Гарантии: метод не прерывает активные сетевые операции, но предотвращает
+ * дальнейшее их создание.
+ */
+public void close() { /* no code */ }
+
+---
+
+## 5) Внутренние типы (nested) — перечень и Javadoc (без реализации)
+
+### 5.1) Результат вызова
+
+/**
+ * Неизменяемый результат HTTP-вызова API Честного знака.
+ * Содержит статус ответа, тело (как строку) и заголовки.
+ * Может включать идентификатор корреляции/трассировки.
+ */
+public static final class Result {
+    /** HTTP статус-код ответа. */
+    public int statusCode;
+    /** Тело ответа в виде строки (может быть пустым). */
+    public String body;
+    /** Заголовки ответа (чувствительность к регистру — по контракту HTTP-клиента). */
+    public java.util.Map<String, java.util.List<String>> headers;
+}
+
+### 5.2) Опции конкретного вызова
+
+/**
+ * Дополнительные опции, применимые к отдельному вызову: локальные таймауты,
+ * идемпотентный ключ, дополнительные заголовки и пр.
+ */
+public static final class CallOptions {
+    /** Заголовки сверх глобальных. */
+    public java.util.Map<String, String> headers;
+    /** Локальный таймаут запроса (если поддерживается HTTP-исполнителем). */
+    public java.time.Duration requestTimeout;
+    /** Пользовательский идемпотентный ключ (если поддерживается API). */
+    public String idempotencyKey;
+}
+
+### 5.3) Исключение уровня API
+
+/**
+ * Общее исключение клиента API, инкапсулирует ошибки сериализации, сетевых
+ * взаимодействий и некорректных ответов сервера.
+ */
+public static class CrptApiException extends Exception {
+    /** Код HTTP-статуса (если доступен). */
+    public Integer statusCode;
+    /** Низкоуровневая причина (IOException, Timeout и пр.). */
+    public Throwable cause;
+    /** Тело ответа сервера (если доступно). */
+    public String responseBody;
+}
+
+### 5.4) Ограничитель запросов (интерфейс)
+
+/**
+ * Интерфейс ограничителя (rate limiter) с блокирующей семантикой.
+ */
+private interface RateLimiter extends AutoCloseable {
+    /**
+     * Блокирующе ожидает разрешение на выполнение запроса.
+     * Может быть прервано через {@link Thread#interrupt()}.
+     * @throws InterruptedException если поток прерван во время ожидания
+     */
+    void acquirePermit() throws InterruptedException;
+
+    /**
+     * Освобождает ресурсы лимитера, если таковые имеются.
+     */
+    @Override
+    void close();
+}
+
+### 5.5) Реализация лимитера — скользящее окно
+
+/**
+ * Реализация скользящего окна: за любой интервал длительностью {@code timeUnit}
+ * не более {@code limit} выполненных запросов. Использует справедливую
+ * синхронизацию и точные ожидания до момента освобождения окна.
+ */
+private static final class SlidingWindowRateLimiter implements RateLimiter {
+    /** Конструктор: принимает {@code timeUnit}, {@code limit} и {@code clock}. */
+    SlidingWindowRateLimiter(java.util.concurrent.TimeUnit timeUnit, int limit, Clock clock) { /* no code */ }
+    /** Реализация блокирующей выдачи разрешения. */
+    @Override public void acquirePermit() throws InterruptedException { /* no code */ }
+    /** Закрытие ресурсов (если есть). */
+    @Override public void close() { /* no code */ }
+}
+
+### 5.6) Источник времени
+
+/** Источник монотонного времени для детерминированных тестов. */
+private interface Clock { long nowNanos(); }
+
+/** Реализация на основе {@link System#nanoTime()}. */
+private static final class SystemClock implements Clock { /* no code */ }
+
+### 5.7) Исполнитель HTTP-запросов
+
+/**
+ * Абстракция HTTP-исполнителя: формирует, отправляет и получает HTTP-запросы/ответы.
+ * Инкапсулирует выбор клиента (java.net.http или другой), таймауты, обработку статусов.
+ */
+private interface HttpExecutor extends AutoCloseable {
+    /**
+     * Выполняет HTTP-вызов.
+     * @param request подготовленный запрос
+     * @return результат ответа (статус, тело, заголовки)
+     * @throws CrptApiException в случае сетевой/протокольной ошибки
+     */
+    Result execute(HttpRequest request) throws CrptApiException;
+
+    /** Закрывает ресурсы HTTP-клиента, если требуется. */
+    @Override void close();
+}
+
+/** Минимальная модель запроса, независимая от конкретного HTTP-клиента. */
+private static final class HttpRequest {
+    public String method;          // Например, "POST"
+    public java.net.URI uri;       // Полный URL
+    public java.util.Map<String, String> headers; // Заголовки
+    public String body;            // Строка JSON
+    public java.time.Duration timeout; // Локальный таймаут, опционально
+}
+
+/** Реализация на основе java.net.http.HttpClient. */
+private static final class JavaHttpClientExecutor implements HttpExecutor {
+    /** Конструктор принимает конфигурацию таймаутов, версию HTTP и пр. */
+    JavaHttpClientExecutor(HttpConfig config) { /* no code */ }
+    @Override public Result execute(HttpRequest request) throws CrptApiException { /* no code */ }
+    @Override public void close() { /* no code */ }
+}
+
+/** Конфигурация HTTP: базовый URL, таймауты, заголовки по умолчанию. */
+private static final class HttpConfig {
+    public java.net.URI baseUri;
+    public java.time.Duration connectTimeout;
+    public java.time.Duration readTimeout;
+    public java.util.Map<String, String> defaultHeaders;
+}
+
+### 5.8) Сериализация JSON
+
+/**
+ * Абстракция сериализации JSON для отделения модели от конкретной библиотеки.
+ */
+private interface JsonSerializer {
+    /** Преобразует объект в JSON-строку. */
+    String toJson(Object value) throws CrptApiException;
+    /** При необходимости — чтение JSON в объект (для ответов). */
+    <T> T fromJson(String json, Class<T> type) throws CrptApiException;
+}
+
+/** Реализация на Jackson (при использовании внешней зависимости). */
+private static final class JacksonJsonSerializer implements JsonSerializer { /* no code */ }
+
+### 5.9) Размещение подписи
+
+/**
+ * Стратегия размещения подписи: в заголовке или в теле запроса (JSON-поле).
+ */
+private enum SignPlacement {
+    /** Подпись отправляется в заголовке (имя заголовка настраивается). */ HEADER,
+    /** Подпись отправляется в теле запроса (имя поля настраивается). */ BODY
+}
+
+### 5.10) Конфигурация клиента (Builder)
+
+/**
+ * Билдер для пошаговой конфигурации клиента: базовый URL, таймауты, заголовки,
+ * сериализатор, HTTP-исполнитель, политика подписи, источник времени и лимитер.
+ */
+public static final class Builder {
+    /** Указывает базовый URL API. */
+    public Builder baseUrl(String url) { return this; }
+    /** Добавляет заголовок по умолчанию. */
+    public Builder defaultHeader(String name, String value) { return this; }
+    /** Таймауты подключения/чтения. */
+    public Builder connectTimeout(java.time.Duration d) { return this; }
+    public Builder readTimeout(java.time.Duration d) { return this; }
+    /** Политика подписи и имена полей/заголовков. */
+    public Builder signPlacement(SignPlacement placement) { return this; }
+    public Builder signatureHeaderName(String name) { return this; }
+    public Builder signatureJsonField(String field) { return this; }
+    /** Задание внешних компонентов. */
+    public Builder httpExecutor(HttpExecutor executor) { return this; }
+    public Builder jsonSerializer(JsonSerializer serializer) { return this; }
+    public Builder rateLimiter(RateLimiter limiter) { return this; }
+    public Builder clock(Clock clock) { return this; }
+    /** Параметры лимита (альтернатива конструктору). */
+    public Builder limit(java.util.concurrent.TimeUnit unit, int requests) { return this; }
+    /** Финальная сборка клиента. */
+    public CrptApi build() { return null; }
+}
+
+---
+
+## 6) Вспомогательные константы/настройки
+
+/** Имя заголовка по умолчанию для подписи (если используется HEADER). */
+private static final String DEFAULT_SIGNATURE_HEADER = "X-Signature";
+/** Имя JSON-поля по умолчанию для подписи (если используется BODY). */
+private static final String DEFAULT_SIGNATURE_FIELD = "signature";
+/** Путь эндпоинта по умолчанию (уточнить по документации ЧЗ). */
+private static final String DEFAULT_CREATE_DOC_PATH = "/api/vX/endpoint";
+
+---
+
+## 7) Примечания по тестируемости (добавить в Javadoc где уместно)
+- Лимитер использует монотонное время через `Clock`, что упрощает юнит-тесты.
+- Метод `createDocumentForDomesticGoods` декларирует `InterruptedException` — ожидаемая реакция на прерывание в блокирующем ожидании.
+- `Result` хранит «сырое» тело ответа и заголовки — это упрощает диагностику и парсинг в вызывающем коде.
+
+---
+
+## 8) Мини-«контракт» метода (для Javadoc)
+- Вход:
+  - document != null; signature != null/не пустая; при нарушении — NPE/IAE.
+- Выход: `Result` с `statusCode`, `body`, `headers`; не null.
+- Ошибки: `InterruptedException` (ожидание лимита), `CrptApiException` (сериализация/HTTP/протокол).
+- Потокобезопасность: множественные параллельные вызовы; справедливое ожидание.
+
+---
+
+## 9) Псевдо-порядок выполнения `createDocumentForDomesticGoods` (для понимания логики)
+1) Вызвать `rateLimiter.acquirePermit()` — возможна блокировка с прерыванием.
+2) Подготовить JSON (включая подпись: в header/body согласно политике).
+3) Сформировать `HttpRequest` (метод POST, URL = baseUrl + path, заголовки, таймаут).
+4) Выполнить запрос через `HttpExecutor` и получить `Result`.
+5) Вернуть `Result` вызывающему коду.
+
+---
+
+## 10) Ссылки в Javadoc (куда стоит сослаться)
+- {@link java.util.concurrent.TimeUnit}
+- {@link java.lang.AutoCloseable}
+- {@link InterruptedException}
+- {@link System#nanoTime()}
+- {@code java.net.http.HttpClient} (если используете его в реализации)
+
+---

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>17</maven.compiler.release>
         <enforcer.java.version>[17,)</enforcer.java.version>
+        <jackson.version>2.17.2</jackson.version>
+        <junit.jupiter.version>5.10.2</junit.jupiter.version>
     </properties>
 
     <build>
@@ -76,11 +78,23 @@
     </build>
 
     <dependencies>
-        <!-- Зависимостей пока нет. Добавьте Jackson/HTTP клиент при необходимости. -->
+        <!-- Jackson JSON -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+
+        <!-- Тесты -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.10.2</version>
+            <version>${junit.jupiter.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/ru/crpt/api/CrptApi.java
+++ b/src/main/java/ru/crpt/api/CrptApi.java
@@ -1,5 +1,15 @@
 package ru.crpt.api;
 
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
@@ -7,9 +17,9 @@ import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Клиент API Честного знака.
- * <p>
  * На данном этапе реализовано ограничение количества
  * запросов в фиксированном временном окне (1 единица {@link TimeUnit}).
+ * Добавлены поддержка HTTP/JSON и каркас метода создания документа.
  * Будущие сетевые методы обязаны вызывать {@link #acquirePermit()} перед
  * обращением к удаленному API.
  */
@@ -17,8 +27,19 @@ public final class CrptApi {
     /** Внутренний лимитер запросов. */
     private final RateLimiter rateLimiter;
 
+    /** HTTP-исполнитель. */
+    private final HttpExecutor httpExecutor;
+    /** JSON-сериализатор. */
+    private final JsonSerializer json;
+    /** Конфигурация HTTP. */
+    private final HttpConfig httpConfig;
+
+    /** Путь эндпоинта по умолчанию для создания документа. */
+    private static final String DEFAULT_CREATE_DOC_PATH = "/api/v3/lk/documents/create";
+
     /**
      * Создает инстанс API клиента с ограничением количества запросов в интервале.
+     * Используются значения по умолчанию для HTTP/JSON: HttpClient и Jackson.
      *
      * @param timeUnit     единица времени, определяющая длину окна (строго 1 единица: 1 секунда, 1 минута и т.п.)
      * @param requestLimit положительное число запросов, допустимых в каждом окне
@@ -31,6 +52,120 @@ public final class CrptApi {
             throw new IllegalArgumentException("requestLimit должен быть > 0");
         }
         this.rateLimiter = new FixedWindowRateLimiter(requestLimit, timeUnit);
+        this.httpConfig = HttpConfig.defaults();
+        this.httpExecutor = new JavaHttpClientExecutor(httpConfig);
+        this.json = new JacksonJsonSerializer();
+    }
+
+    /**
+     * Конструктор из билдера для расширенной конфигурации.
+     */
+    CrptApi(Builder b) {
+        Objects.requireNonNull(b, "builder");
+        this.rateLimiter = b.rateLimiter != null ? b.rateLimiter : new FixedWindowRateLimiter(b.limitRequests, b.limitUnit);
+        this.httpConfig = b.httpConfig != null ? b.httpConfig : HttpConfig.defaults();
+        this.httpExecutor = b.httpExecutor != null ? b.httpExecutor : new JavaHttpClientExecutor(this.httpConfig);
+        this.json = b.json != null ? b.json : new JacksonJsonSerializer();
+    }
+
+    // ------------------- ПУБЛИЧНЫЕ МЕТОДЫ API -------------------
+
+    /** Результат HTTP-вызова. */
+    public static final class Result {
+        public final int statusCode;
+        public final String body;
+        public final Map<String, List<String>> headers;
+        public Result(int statusCode, String body, Map<String, List<String>> headers) {
+            this.statusCode = statusCode;
+            this.body = body;
+            this.headers = headers == null ? Map.of() : headers;
+        }
+    }
+
+    /** Опции вызова. */
+    public static final class CallOptions {
+        public final Map<String, String> headers;
+        public final Duration requestTimeout;
+        public final String productGroup; // альтернативно pg в query
+        public CallOptions(Map<String, String> headers, Duration requestTimeout, String productGroup) {
+            this.headers = headers;
+            this.requestTimeout = requestTimeout;
+            this.productGroup = productGroup;
+        }
+        public static CallOptions ofProductGroup(String pg) {
+            return new CallOptions(null, null, pg);
+        }
+    }
+
+    /** Общее исключение уровня клиента. */
+    public static class CrptApiException extends Exception {
+        public final Integer statusCode;
+        public final String responseBody;
+        public CrptApiException(String message, Throwable cause) { super(message, cause); this.statusCode = null; this.responseBody = null; }
+        public CrptApiException(String message, Integer statusCode, String responseBody) { super(message); this.statusCode = statusCode; this.responseBody = responseBody; }
+    }
+
+    /**
+     * Создание документа для ввода в оборот товара, произведённого в РФ.
+     * Каркас: выполняется ограничение по частоте, подготовка JSON и HTTP-запроса.
+     *
+     * @param document  объект документа доменной модели (будет сериализован в JSON и обёрнут в Base64)
+     * @param signature откреплённая подпись (УКЭП, CMS/PKCS#7) в Base64
+     * @return результат HTTP-вызова
+     * @throws NullPointerException  если аргументы null
+     * @throws InterruptedException  при прерывании ожидания разрешения лимитером
+     * @throws CrptApiException      при ошибках сериализации/HTTP
+     */
+    public Result createDocumentForDomesticGoods(Object document, String signature)
+            throws InterruptedException, CrptApiException {
+        return createDocumentForDomesticGoods(document, signature, null);
+    }
+
+    /** Перегрузка с опциями вызова. См. описание основного метода. */
+    public Result createDocumentForDomesticGoods(Object document, String signature, CallOptions options)
+            throws InterruptedException, CrptApiException {
+        Objects.requireNonNull(document, "document");
+        Objects.requireNonNull(signature, "signature");
+
+        // 1) Ограничение частоты
+        acquirePermit();
+
+        try {
+            // 2) Сериализуем исходный объект документа в JSON и кодируем Base64
+            String docJson = json.toJson(document);
+            String productDocument = Base64.getEncoder().encodeToString(docJson.getBytes(StandardCharsets.UTF_8));
+
+            // 3) Формируем полезную нагрузку запроса
+            CreateDocRequest payload = new CreateDocRequest(
+                    "MANUAL", // формат: JSON
+                    productDocument,
+                    options != null ? options.productGroup : null,
+                    signature,
+                    "LP_INTRODUCE_GOODS"
+            );
+            String body = json.toJson(payload);
+
+            // 4) Строим URL: baseUri + path + optional ?pg=
+            URI uri = httpConfig.baseUri.resolve(DEFAULT_CREATE_DOC_PATH + buildPgQuerySuffix(options));
+
+            // 5) Заголовки: объединяем дефолтные + опциональные из CallOptions
+            Map<String, String> headers = new HashMap<>(httpConfig.defaultHeaders);
+            headers.putIfAbsent("Content-Type", "application/json");
+            if (options != null && options.headers != null) headers.putAll(options.headers);
+
+            // 6) Выполняем HTTP
+            HttpReq req = new HttpReq("POST", uri, headers, body, options != null ? options.requestTimeout : httpConfig.readTimeout);
+            return httpExecutor.execute(req);
+        } catch (CrptApiException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new CrptApiException("Ошибка подготовки или выполнения запроса", e);
+        }
+    }
+
+    private static String buildPgQuerySuffix(CallOptions options) {
+        if (options == null || options.productGroup == null || options.productGroup.isBlank()) return "";
+        return "?pg=" + options.productGroup;
     }
 
     // ------------------- ВСПОМОГАТЕЛЬНЫЕ МЕТОДЫ ДЛЯ БУДУЩИХ ВЫЗОВОВ -------------------
@@ -54,13 +189,170 @@ public final class CrptApi {
         return rateLimiter.tryAcquire();
     }
 
-    // ------------------- ВНУТРЕННИЕ ТИПЫ -------------------
+    // ------------------- ВНУТРЕННИЕ ТИПЫ: HTTP/JSON/DTO -------------------
 
     /** Простейший контракт лимитера. */
     interface RateLimiter {
         void acquire() throws InterruptedException;
         boolean tryAcquire();
     }
+
+    /** HTTP запрос для внутреннего исполнителя. */
+    static final class HttpReq {
+        final String method;
+        final URI uri;
+        final Map<String, String> headers;
+        final String body;
+        final Duration timeout;
+        HttpReq(String method, URI uri, Map<String, String> headers, String body, Duration timeout) {
+            this.method = method;
+            this.uri = uri;
+            this.headers = headers;
+            this.body = body;
+            this.timeout = timeout;
+        }
+    }
+
+    /** Конфигурация HTTP. */
+    static final class HttpConfig {
+        final URI baseUri;
+        final Duration connectTimeout;
+        final Duration readTimeout;
+        final Map<String, String> defaultHeaders;
+        HttpConfig(URI baseUri, Duration connectTimeout, Duration readTimeout, Map<String, String> defaultHeaders) {
+            this.baseUri = baseUri;
+            this.connectTimeout = connectTimeout;
+            this.readTimeout = readTimeout;
+            this.defaultHeaders = defaultHeaders == null ? Map.of() : Map.copyOf(defaultHeaders);
+        }
+        static HttpConfig defaults() {
+            return new HttpConfig(
+                    URI.create("https://ismp.crpt.ru"),
+                    Duration.ofSeconds(10),
+                    Duration.ofSeconds(30),
+                    Map.of()
+            );
+        }
+    }
+
+    /** Интерфейс HTTP-исполнителя. */
+    interface HttpExecutor extends AutoCloseable {
+        Result execute(HttpReq request) throws CrptApiException;
+        @Override default void close() { /* no-op */ }
+    }
+
+    /** Реализация на java.net.http.HttpClient. */
+    static final class JavaHttpClientExecutor implements HttpExecutor {
+        private final HttpClient client;
+        private final HttpConfig cfg;
+        JavaHttpClientExecutor(HttpConfig cfg) {
+            this.cfg = cfg;
+            this.client = HttpClient.newBuilder()
+                    .connectTimeout(cfg.connectTimeout)
+                    .build();
+        }
+        @Override
+        public Result execute(HttpReq r) throws CrptApiException {
+            try {
+                HttpRequest.Builder b = HttpRequest.newBuilder()
+                        .uri(r.uri)
+                        .timeout(r.timeout != null ? r.timeout : cfg.readTimeout);
+                if ("POST".equalsIgnoreCase(r.method)) {
+                    b = b.POST(HttpRequest.BodyPublishers.ofString(r.body != null ? r.body : ""));
+                } else if ("GET".equalsIgnoreCase(r.method)) {
+                    b = b.GET();
+                } else if ("DELETE".equalsIgnoreCase(r.method)) {
+                    b = b.DELETE();
+                } else if ("PUT".equalsIgnoreCase(r.method)) {
+                    b = b.PUT(HttpRequest.BodyPublishers.ofString(r.body != null ? r.body : ""));
+                } else {
+                    throw new IllegalArgumentException("Неподдерживаемый метод: " + r.method);
+                }
+                if (r.headers != null) {
+                    r.headers.forEach(b::header);
+                }
+                HttpResponse<String> resp = client.send(b.build(), HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+                return new Result(resp.statusCode(), resp.body(), resp.headers().map());
+            } catch (Exception e) {
+                throw new CrptApiException("Ошибка HTTP-вызова", e);
+            }
+        }
+    }
+
+    /** Интерфейс сериализации JSON. */
+    interface JsonSerializer {
+        String toJson(Object value) throws Exception;
+        <T> T fromJson(String json, Class<T> type) throws Exception;
+    }
+
+    /** Реализация на Jackson. */
+    static final class JacksonJsonSerializer implements JsonSerializer {
+        private final com.fasterxml.jackson.databind.ObjectMapper mapper;
+        JacksonJsonSerializer() {
+            mapper = new com.fasterxml.jackson.databind.ObjectMapper();
+            mapper.findAndRegisterModules(); // jsr310 и т.п.
+            mapper.setSerializationInclusion(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL);
+        }
+        @Override public String toJson(Object value) throws Exception { return mapper.writeValueAsString(value); }
+        @Override public <T> T fromJson(String json, Class<T> type) throws Exception { return mapper.readValue(json, type); }
+    }
+
+    /** DTO: тело запроса создания документа. */
+    static final class CreateDocRequest {
+        public final String document_format;
+        public final String product_document;
+        public final String product_group; // опционально
+        public final String signature;
+        public final String type;
+        CreateDocRequest(String document_format, String product_document, String product_group, String signature, String type) {
+            this.document_format = document_format;
+            this.product_document = product_document;
+            this.product_group = product_group;
+            this.signature = signature;
+            this.type = type;
+        }
+    }
+
+    /** DTO: успешный ответ создания документа. */
+    static final class CreateDocResponse { public String value; }
+
+    // ------------------- BUILDER -------------------
+
+    public static final class Builder {
+        private RateLimiter rateLimiter;
+        private TimeUnit limitUnit = TimeUnit.SECONDS;
+        private int limitRequests = 10;
+        private HttpConfig httpConfig;
+        private HttpExecutor httpExecutor;
+        private JsonSerializer json;
+
+        public Builder limit(TimeUnit unit, int requests) { this.limitUnit = Objects.requireNonNull(unit); this.limitRequests = requests; return this; }
+        public Builder baseUrl(String baseUrl) {
+            HttpConfig base = httpConfig == null ? HttpConfig.defaults() : httpConfig;
+            this.httpConfig = new HttpConfig(URI.create(baseUrl), base.connectTimeout, base.readTimeout, base.defaultHeaders);
+            return this;
+        }
+        public Builder defaultHeader(String name, String value) {
+            HttpConfig base = httpConfig == null ? HttpConfig.defaults() : httpConfig;
+            Map<String,String> map = new HashMap<>(base.defaultHeaders);
+            map.put(name, value);
+            this.httpConfig = new HttpConfig(base.baseUri, base.connectTimeout, base.readTimeout, map);
+            return this;
+        }
+        public Builder authBearer(String token) { return defaultHeader("Authorization", "Bearer " + token); }
+        public Builder contentTypeJson() { return defaultHeader("Content-Type", "application/json"); }
+        public Builder timeouts(Duration connect, Duration read) {
+            HttpConfig base = httpConfig == null ? HttpConfig.defaults() : httpConfig;
+            this.httpConfig = new HttpConfig(base.baseUri, connect, read, base.defaultHeaders);
+            return this;
+        }
+        public Builder httpExecutor(HttpExecutor exec) { this.httpExecutor = exec; return this; }
+        public Builder json(JsonSerializer serializer) { this.json = serializer; return this; }
+        public Builder rateLimiter(RateLimiter limiter) { this.rateLimiter = limiter; return this; }
+        public CrptApi build() { if (httpConfig == null) httpConfig = HttpConfig.defaults(); return new CrptApi(this); }
+    }
+
+    // ------------------- RATE LIMITER -------------------
 
     /**
      * Реализация лимитера с фиксированным окном: не более N запросов за 1 интервал timeUnit.


### PR DESCRIPTION
add: JSON-сериализация на Jackson (JacksonJsonSerializer) и интерфейс JsonSerializer
add: конфигурация HttpConfig и Builder (baseUrl, defaultHeader, authBearer, contentTypeJson, timeouts, json/httpExecutor, rateLimiter, limit)
add: DTO: CreateDocRequest, CreateDocResponse, Result, CallOptions
add: публичный метод createDocumentForDomesticGoods(...) — лимитер, Base64(JSON), signature, поддержка ?pg и заголовков из CallOptions
add: зависимости Jackson (jackson-databind, jackson-datatype-jsr310) в pom.xml
add: конспект эндпоинта docs/CHZ-create-document-v3.md
fix: стабилизация юнит‑тестов лимитера